### PR TITLE
added WebAPI like features

### DIFF
--- a/util/createController-es6.js
+++ b/util/createController-es6.js
@@ -22,7 +22,9 @@ function createController(app, controllerPath, overrides = { }){
         if (methodOverrides.nonRoutable) return;
 
         let verbsToUse = methodOverrides.httpMethod || defaultVerb || ['get'],
-            actionPath = methodOverrides.route || method;
+            actionPath = methodOverrides.route;
+            
+        if (actionPath == null) actionPath = verbsToUse.includes(method) ? '' : method;
 
         if (actionPath[0] == '/'){
             //global path - add right to express


### PR DESCRIPTION
Added two WebAPI-like features

- ```@route('')``` now means 'make my route without action name' instead of 'leave action name = method name'
- in case method name == http method then assume that action name = ''

example
```js
export default class Wallets{

    // binds as GET:/wallets instead of GET:/wallets/get 
    get(){
        this.send({ saved: 0 });
    }   

    // binds as POST:/wallets instead of POST:/wallets/make 
    @route('')
    @httpPost
    make(){
        this.send({ saved: 2 });
    }  
}
```