### PR TITLE
Made httpDecorators accept route as an argument

### DIFF
--- a/controllers/ExtendedDecorators-es6.js
+++ b/controllers/ExtendedDecorators-es6.js
@@ -1,0 +1,35 @@
+const { httpGet, httpPut, httpDelete, httpPost, httpPatch, acceptVerbs, route, nonRoutable } = require('../index');
+
+class ExtendedDecorators {
+    @httpGet('get-test')
+    get(){
+        this.send({getReceived: true});
+    }
+
+    @httpPost('post-test')
+    post(){
+        this.send({postReceived: true});
+    }
+
+    @httpDelete('delete-test')
+    delete(){
+        this.send({deleteReceived: true});
+    }
+
+    @httpPut('put-test')
+    put(){
+        this.send({putReceived: true});
+    }
+
+    @httpPatch('patch-test')
+    patch(){
+        this.send({patchReceived: true});
+    }
+
+    @httpPost('')
+    realPost(){
+        this.send({postReceived: true});
+    }
+}
+
+module.exports = ExtendedDecorators;

--- a/controllers/NewRouting3-es6.js
+++ b/controllers/NewRouting3-es6.js
@@ -1,6 +1,6 @@
 const { httpGet, httpPut, httpDelete, httpPost, acceptVerbs, route, nonRoutable } = require('../index');
 
-class NewRouting2 {
+class NewRouting3 {
     @httpPost
     @route('')
     get(){
@@ -26,4 +26,4 @@ class NewRouting2 {
     }
 }
 
-module.exports = NewRouting2;
+module.exports = NewRouting3;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -57,6 +57,7 @@ gulp.task('test', function () {
 	easyControllers.createController(app, 'NewRouting');
 	easyControllers.createController(app, 'NewRouting2');
 	easyControllers.createController(app, 'NewRouting3');
+	easyControllers.createController(app, 'ExtendedDecorators');
 	easyControllers.createController(app, 'GlobalController');
 	easyControllers.createController(app, 'publisher/publisherDetails');
 	easyControllers.createController(app, 'books/Book');

--- a/index-es6.js
+++ b/index-es6.js
@@ -6,6 +6,7 @@ var {
     httpPost,
     httpPut,
     httpDelete,
+    httpPatch,
     acceptVerbs,
     route,
     nonRoutable
@@ -23,6 +24,7 @@ module.exports = {
     httpPost,
     httpPut,
     httpDelete,
+    httpPatch,
     acceptVerbs,
     route,
     nonRoutable

--- a/testUtil/testSetup-es6.js
+++ b/testUtil/testSetup-es6.js
@@ -35,6 +35,10 @@ function putAndCheck(uri, data, done, check, options){
     runAndCheck(uri, data, 'put', done, check);
 }
 
+function patchAndCheck(uri, data, done, check, options){
+    runAndCheck(uri, data, 'patch', done, check);
+}
+
 function deleteAndCheck(uri, data, done, check, options){
     runAndCheck(uri, data, 'delete', done, check);
 }
@@ -56,7 +60,10 @@ function verbsAreRejected(uri, done, verbs){
 
     function runVerb(verb){
         return new Promise(res => {
-            request[verb](uri, {}, function (error, response, obj) {
+            let regVerb = verb;
+            if(regVerb == 'delete') regVerb = 'del';
+
+            request[regVerb](uri, {}, function (error, response, obj) {
                 assert.isTrue(new RegExp(`cannot ${verb}`, 'i').test(obj), `${uri} didn't fail for ${verb} but should have`); //this is how request handles requests for which the very is not defined....
                 res();
             });
@@ -92,6 +99,7 @@ global.utils = {
     postAndCheck,
     getAndCheck,
     putAndCheck,
+    patchAndCheck,
     deleteAndCheck,
     runAndCheck,
     verbsAreRejected,

--- a/tests/coreRoutingTests-es6.js
+++ b/tests/coreRoutingTests-es6.js
@@ -150,4 +150,30 @@ describe('Controller routing tests', function(){
         utils.putAndCheck('http://localhost:3000/NewRouting3/', { }, done, obj => assert.isTrue(obj.putReceived));
     });
 
+    //exteneded decorators
+
+    it('exteneded decorators - get', function(done){
+        utils.getAndCheck('http://localhost:3000/ExtendedDecorators/get-test', { }, done, obj => assert.isTrue(obj.getReceived));
+    });
+
+    it('exteneded decorators - post', function(done){
+        utils.postAndCheck('http://localhost:3000/ExtendedDecorators/post-test', { }, done, obj => assert.isTrue(obj.postReceived));
+    });
+
+    it('exteneded decorators - delete', function(done){
+        utils.deleteAndCheck('http://localhost:3000/ExtendedDecorators/delete-test', { }, done, obj => assert.isTrue(obj.deleteReceived));
+    });
+
+    it('exteneded decorators - put', function(done){
+        utils.putAndCheck('http://localhost:3000/ExtendedDecorators/put-test', { }, done, obj => assert.isTrue(obj.putReceived));
+    });
+
+    it('exteneded decorators - patch', function(done){
+        utils.patchAndCheck('http://localhost:3000/ExtendedDecorators/patch-test', { }, done, obj => assert.isTrue(obj.patchReceived));
+    });
+
+    it('exteneded decorators - empty route', function(done){
+        utils.postAndCheck('http://localhost:3000/ExtendedDecorators', { }, done, obj => assert.isTrue(obj.postReceived));
+    });
+
 });


### PR DESCRIPTION
Added shortcuts for route decorator by using argument in http*

Example
```js
export default class DataController{

    // so this
    @httpGet('getdata/:id')
    getdata(id){
        this.send({ saved: 0 });
    }    

    // equals to this
    @httpGet
    @route('getdata/:id')
    getdata(id){
        this.send({ saved: 0 });
    }     
}
```